### PR TITLE
Attempts to fix the notes fetching process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,6 +4105,7 @@ dependencies = [
 [[package]]
 name = "namada_account"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4116,6 +4117,7 @@ dependencies = [
 [[package]]
 name = "namada_controller"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -4125,6 +4127,7 @@ dependencies = [
 [[package]]
 name = "namada_core"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "bech32 0.11.0",
  "borsh",
@@ -4173,6 +4176,7 @@ dependencies = [
 [[package]]
 name = "namada_ethereum_bridge"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "ethers",
@@ -4200,6 +4204,7 @@ dependencies = [
 [[package]]
 name = "namada_events"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4213,6 +4218,7 @@ dependencies = [
 [[package]]
 name = "namada_gas"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4225,6 +4231,7 @@ dependencies = [
 [[package]]
 name = "namada_governance"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -4247,6 +4254,7 @@ dependencies = [
 [[package]]
 name = "namada_ibc"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -4281,6 +4289,7 @@ dependencies = [
 [[package]]
 name = "namada_io"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "async-trait",
  "kdam",
@@ -4293,6 +4302,7 @@ dependencies = [
 [[package]]
 name = "namada_macros"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -4304,6 +4314,7 @@ dependencies = [
 [[package]]
 name = "namada_merkle_tree"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "eyre",
@@ -4318,6 +4329,7 @@ dependencies = [
 [[package]]
 name = "namada_parameters"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -4332,6 +4344,7 @@ dependencies = [
 [[package]]
 name = "namada_proof_of_stake"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -4355,6 +4368,7 @@ dependencies = [
 [[package]]
 name = "namada_replay_protection"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "namada_core",
 ]
@@ -4362,6 +4376,7 @@ dependencies = [
 [[package]]
 name = "namada_sdk"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "async-trait",
  "bech32 0.11.0",
@@ -4432,6 +4447,7 @@ dependencies = [
 [[package]]
 name = "namada_shielded_token"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4472,6 +4488,7 @@ dependencies = [
 [[package]]
 name = "namada_state"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "clru",
@@ -4494,6 +4511,7 @@ dependencies = [
 [[package]]
 name = "namada_storage"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
@@ -4512,6 +4530,7 @@ dependencies = [
 [[package]]
 name = "namada_systems"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -4521,6 +4540,7 @@ dependencies = [
 [[package]]
 name = "namada_token"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4538,6 +4558,7 @@ dependencies = [
 [[package]]
 name = "namada_trans_token"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "konst",
  "namada_core",
@@ -4554,6 +4575,7 @@ dependencies = [
 [[package]]
 name = "namada_tx"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.9.0",
@@ -4582,6 +4604,7 @@ dependencies = [
 [[package]]
 name = "namada_tx_env"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -4591,6 +4614,7 @@ dependencies = [
 [[package]]
 name = "namada_vm"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "clru",
@@ -4612,6 +4636,7 @@ dependencies = [
 [[package]]
 name = "namada_vote_ext"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "borsh",
  "namada_core",
@@ -4623,6 +4648,7 @@ dependencies = [
 [[package]]
 name = "namada_vp"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -4638,6 +4664,7 @@ dependencies = [
 [[package]]
 name = "namada_vp_env"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -4652,6 +4679,7 @@ dependencies = [
 [[package]]
 name = "namada_wallet"
 version = "0.48.0"
+source = "git+https://github.com/anoma/namada?rev=6a088b2e148fbb976d0727f17846c383dcad052c#6a088b2e148fbb976d0727f17846c383dcad052c"
 dependencies = [
  "bimap",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,8 +851,8 @@ name = "client"
 version = "0.0.1"
 dependencies = [
  "clap",
- "fuzzy-message-detection",
  "hex",
+ "polyfuzzy",
  "rand_core",
  "serde_cbor",
  "serde_json",
@@ -2059,7 +2059,7 @@ dependencies = [
 name = "fmd-enclave-service"
 version = "0.0.1"
 dependencies = [
- "fuzzy-message-detection",
+ "polyfuzzy",
  "shared",
  "x25519-dalek",
 ]
@@ -2273,17 +2273,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fuzzy-message-detection"
-version = "0.1.0"
-dependencies = [
- "curve25519-dalek",
- "rand_core",
- "serde",
- "sha2 0.10.8",
- "subtle",
 ]
 
 [[package]]
@@ -5357,6 +5346,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyfuzzy"
+version = "0.1.0"
+source = "git+https://github.com/anoma/shielded-state-sync#f0c4dc06219db3192f74a8f67b64f29e01410bb1"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6397,8 +6398,8 @@ version = "0.0.1"
 dependencies = [
  "chacha20poly1305",
  "cobs 0.3.0",
- "fuzzy-message-detection",
  "hex",
+ "polyfuzzy",
  "rand_core",
  "serde",
  "serde_cbor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,9 +2519,14 @@ dependencies = [
 name = "host"
 version = "0.0.1"
 dependencies = [
+ "borsh",
  "clap",
+ "eyre",
+ "flume",
+ "futures",
  "home",
  "namada_sdk",
+ "rayon",
  "reqwest 0.12.15",
  "rusqlite",
  "serde",
@@ -3753,7 +3758,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph 0.6.5",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3767,7 +3772,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -3912,6 +3917,15 @@ dependencies = [
  "nam-redjubjub",
  "rand_core",
  "tracing",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -5456,7 +5470,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "unarray",
 ]
 
@@ -5640,8 +5654,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5652,8 +5675,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7234,10 +7263,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,6 +2533,7 @@ dependencies = [
  "serde_cbor",
  "shared",
  "tokio",
+ "tokio-scoped",
  "toml",
  "tracing",
  "tracing-log",
@@ -7098,6 +7099,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls 0.23.25",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-scoped"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4beb8ba13bc53ac53ce1d52b42f02e5d8060f0f42138862869beb769722b256"
+dependencies = [
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ exclude = [
 members = [ "client", "enclave", "host", "shared", "transparent"]
 
 [workspace.dependencies]
+borsh = "1.2"
 clap = { version = "4.5.32", features = ["derive"] }
+eyre = "0.6.12"
+flume = "0.11.1"
 fmd = {package = "fuzzy-message-detection", path = "../shielded-state-sync/fuzzy-message-detection", features = ["serde"]} #git = "https://github.com/anoma/shielded-state-sync" }
 hex = { version = "0.4.3", default-features = false }
 home = "0.5.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ borsh = "1.2"
 clap = { version = "4.5.32", features = ["derive"] }
 eyre = "0.6.12"
 flume = "0.11.1"
-fmd = {package = "fuzzy-message-detection", path = "../shielded-state-sync/fuzzy-message-detection", features = ["serde"]} #git = "https://github.com/anoma/shielded-state-sync" }
+fmd = {package = "polyfuzzy", git = "https://github.com/anoma/shielded-state-sync", features = ["serde"]}
 hex = { version = "0.4.3", default-features = false }
 home = "0.5.11"
 rand_core = { version = "0.6", default-features = false }

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 edition = "2024"
 
 [dependencies]
-fmd = {package = "fuzzy-message-detection", path = "../../shielded-state-sync/fuzzy-message-detection", features = ["serde"]}
+fmd.workspace = true
 shared = { path = "../shared" }
 x25519-dalek = "2.0.1"
 

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -49,7 +49,7 @@ where
             Ok(msg) => match msg {
                 MsgFromHost::RegisterKey { nonce, pk } => {
                     if let Some(key) =
-                        ratls::register_key(ctx.clone(), x25519_dalek::PublicKey::from(pk.0), nonce)
+                        ratls::register_key(&mut ctx, x25519_dalek::PublicKey::from(pk.0), nonce)
                     {
                         registered_keys.push(key);
                     }

--- a/enclave/src/ratls.rs
+++ b/enclave/src/ratls.rs
@@ -24,7 +24,7 @@ use crate::Ctx;
 /// Upon success, the secure channel is used to send an FMD key to the enclave
 /// to be stored.
 pub(crate) fn register_key<RA, COM, RNG>(
-    mut ctx: Ctx<RA, COM, RNG>,
+    ctx: &mut Ctx<RA, COM, RNG>,
     pk: x25519_dalek::PublicKey,
     nonce: u64,
 ) -> Option<CompactSecretKey>

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -5,9 +5,14 @@ version = "0.0.1"
 edition = "2024"
 
 [dependencies]
+borsh.workspace = true
 clap.workspace = true
+eyre.workspace = true
 home.workspace = true
+flume.workspace = true
+futures = "0.3.31"
 namada = {package = "namada_sdk", path = "../../namada/crates/sdk" }
+rayon = "1.10.0"
 reqwest.workspace = true
 rusqlite = { version = "0.34.0", features = ["bundled"] }
 serde_cbor = { workspace = true, features = ["std"] }
@@ -16,5 +21,5 @@ tokio = { version = "1.44.1", features = ["full"] }
 toml.workspace = true
 tracing.workspace = true
 tracing-log.workspace = true
-tracing-subscriber.workspace = true
-serde = { version = "1.0.218", features = ["derive"] }
+tracing-subscriber  = { workspace = true, features = ["env-filter"] }
+serde = { workspace = true, features = ["std"] }

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -11,7 +11,7 @@ eyre.workspace = true
 home.workspace = true
 flume.workspace = true
 futures = "0.3.31"
-namada = {package = "namada_sdk", path = "../../namada/crates/sdk" }
+namada = { package = "namada_sdk", git = "https://github.com/anoma/namada", rev =  "6a088b2e148fbb976d0727f17846c383dcad052c" }
 rayon = "1.10.0"
 reqwest = { workspace = true }
 rusqlite = { version = "0.34.0", features = ["bundled"] }

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -13,11 +13,12 @@ flume.workspace = true
 futures = "0.3.31"
 namada = {package = "namada_sdk", path = "../../namada/crates/sdk" }
 rayon = "1.10.0"
-reqwest.workspace = true
+reqwest = { workspace = true }
 rusqlite = { version = "0.34.0", features = ["bundled"] }
 serde_cbor = { workspace = true, features = ["std"] }
 shared = { path = "../shared", features = ["std"] }
 tokio = { version = "1.44.1", features = ["full"] }
+tokio-scoped = "0.2.0"
 toml.workspace = true
 tracing.workspace = true
 tracing-log.workspace = true

--- a/host/src/com.rs
+++ b/host/src/com.rs
@@ -90,7 +90,7 @@ impl IncomingTcp {
     /// received within time.
     pub async fn timed_read(&mut self) -> Option<Result<ClientMsg, MsgError>> {
         tokio_scoped::scope(|scope| {
-            scope.block_on( async {
+            scope.block_on(async {
                 tokio::select! {
                     _ = tokio::time::sleep(self.timeout) => None,
                     val = async { self.read() } => Some(val),

--- a/host/src/db.rs
+++ b/host/src/db.rs
@@ -1,55 +1,102 @@
 //! Implementation of the backing DB of the service.
-use std::thread::JoinHandle;
 
+mod fetch;
+mod utils;
+
+use eyre::WrapErr;
 use rusqlite::Connection;
+pub use utils::DropFlag;
 
 use crate::config::kassandra_dir;
+use crate::db::fetch::Fetcher;
 
 const MASP_DB_PATH: &str = "masp.db3";
 const FMD_DB_PATH: &str = "fmd.db3";
 
+/// The backing database implementation
 pub struct DB {
+    /// Connection to the DB holding MASP txs
     masp: Connection,
+    /// Connection to the DB holding the index sets for registered keys
     fmd: Connection,
+    /// A handle to the job updating the MASP DB
+    updating: Option<std::thread::JoinHandle<Result<(), eyre::Error>>>,
 }
 
 impl DB {
     /// Create new connections to the dbs. Creates directories/files and initializes
     /// tables if necessary.
-    pub fn new() -> rusqlite::Result<Self> {
+    pub fn new() -> eyre::Result<Self> {
         let masp_db_path = kassandra_dir().join(MASP_DB_PATH);
         let masp = if !masp_db_path.exists() {
-            let masp = Connection::open(masp_db_path)?;
+            let masp = Connection::open(masp_db_path).wrap_err("Failed to open the MAPS DB")?;
             masp.execute(
-                "CREATE TABLE txs (
+                "CREATE TABLE Txs (
                 id INTEGER PRIMARY KEY,
-                idx INTEGER NOT NULL,
+                idx BLOB NOT NULL,
                 data BLOB NOT NULL,
-                flag BLOB NOT NULL
+                flag BLOB
                 )",
                 (),
-            )?;
+            )
+            .wrap_err("Failed to create MASP DB table")?;
             masp
         } else {
-            Connection::open(masp_db_path)?
+            Connection::open(masp_db_path).wrap_err("Failed to open the MAPS DB")?
         };
 
         let fmd_db_path = kassandra_dir().join(FMD_DB_PATH);
         let fmd = if !fmd_db_path.exists() {
-            let fmd = Connection::open(fmd_db_path)?;
+            let fmd = Connection::open(fmd_db_path).wrap_err("Failed to open the FMD DB")?;
             fmd.execute(
-                "CREATE TABLE indices (
+                "CREATE TABLE Indices (
                 id INTEGER PRIMARY KEY,
                 owner BLOB NOT NULL,
                 idx_set BLOC NOT NULL
             )",
                 (),
-            )?;
+            )
+            .wrap_err("Failed to creat FMD DB table")?;
             fmd
         } else {
-            Connection::open(fmd_db_path)?
+            Connection::open(fmd_db_path).wrap_err("Failed to creat FMD DB table")?
         };
 
-        Ok(Self { masp, fmd })
+        Ok(Self {
+            masp,
+            fmd,
+            updating: None,
+        })
+    }
+
+    /// Spawn the update job in the background and save a handle to it.
+    pub fn start_updates(
+        &mut self,
+        url: reqwest::Url,
+        max_wal_size: usize,
+        interrupt: DropFlag,
+    ) -> eyre::Result<()> {
+        let masp_db_path = kassandra_dir().join(MASP_DB_PATH);
+        let conn = Connection::open(masp_db_path).wrap_err("Failed to creat MASP DB table")?;
+        let mut fetcher = Fetcher::new(url, conn, max_wal_size)?;
+        let handle = std::thread::spawn(|| {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async move { fetcher.run().await })?;
+            drop(interrupt);
+            Ok(())
+        });
+        self.updating = Some(handle);
+        Ok(())
+    }
+
+    pub fn close(mut self) {
+        tracing::info!(
+            "Closing the DB and stopping the update job. Please be patient, this can take some time..."
+        );
+        _ = self.masp.close();
+        _ = self.fmd.close();
+        if let Some(update) = self.updating.take() {
+            _ = update.join().unwrap();
+        }
     }
 }

--- a/host/src/db.rs
+++ b/host/src/db.rs
@@ -80,9 +80,10 @@ impl DB {
         let conn = Connection::open(masp_db_path).wrap_err("Failed to creat MASP DB table")?;
         let mut fetcher = Fetcher::new(url, conn, max_wal_size)?;
         let handle = tokio::task::spawn(async move {
-            fetcher.run().await?;
+            let ret = fetcher.run().await;
+            fetcher.save();
             drop(interrupt);
-            Ok(())
+            ret
         });
         self.updating = Some(handle);
         Ok(())

--- a/host/src/db/fetch.rs
+++ b/host/src/db/fetch.rs
@@ -1,0 +1,296 @@
+use std::ops::ControlFlow;
+use std::pin::Pin;
+use std::task::Poll;
+use std::time::Duration;
+
+use borsh::BorshDeserialize;
+use eyre::{Context, eyre};
+use futures::future::{Either, select};
+use namada::borsh::BorshSerializeExt;
+use namada::chain::BlockHeight;
+use namada::control_flow::{ShutdownSignal, ShutdownSignalChan, install_shutdown_signal};
+use namada::hints;
+use namada::masp::IndexerMaspClient;
+use namada::masp::utils::{IndexedNoteData, IndexedNoteEntry, MaspClient};
+use rusqlite::Connection;
+
+use crate::config::kassandra_dir;
+use crate::db::utils::{AsyncCounter, AtomicFlag, FetchedRanges, PanicFlag, TaskError};
+
+const BATCH_SIZE: usize = 30;
+const DEFAULT_BUF_SIZE: usize = 32;
+
+const FETCHER_FILE: &str = "fetcher.dat";
+pub type Fetched =
+    Result<(BlockHeight, BlockHeight, Vec<IndexedNoteEntry>), TaskError<[BlockHeight; 2]>>;
+
+/// The tasks fetching data from a MASP indexer
+struct Tasks {
+    message_receiver: flume::Receiver<Fetched>,
+    message_sender: flume::Sender<Fetched>,
+    /// A thread-safe counter of the number of tasks running
+    active_tasks: AsyncCounter,
+    /// A thread-safe flag indicating a panic happened in a task
+    panic_flag: PanicFlag,
+}
+
+impl Tasks {
+    async fn get_next_message(&mut self, interrupt: AtomicFlag) -> Option<Fetched> {
+        if interrupt.get() {
+            return None;
+        }
+        if let Either::Left((maybe_message, _)) =
+            select(self.message_receiver.recv_async(), &mut self.active_tasks).await
+        {
+            let Ok(message) = maybe_message else {
+                unreachable!("There must be at least one sender alive");
+            };
+            Some(message)
+        } else {
+            // NB: queueing a message to a channel doesn't mean we
+            // actually consume it. we must wait for the channel to
+            // be drained when all tasks have returned. the spin loop
+            // hint below helps the compiler to optimize the `try_recv`
+            // branch, to avoid maxing out the cpu.
+            std::hint::spin_loop();
+            self.message_receiver.try_recv().ok()
+        }
+    }
+}
+
+#[derive(Debug)]
+enum FetcherState {
+    Normal,
+    Interrupted,
+    Errored(eyre::Error),
+}
+
+/// A buffered DB connection
+struct DbConn {
+    conn: Connection,
+    wal: IndexedNoteData,
+    max_wal_size: usize,
+}
+
+impl DbConn {
+    fn extend<I>(&mut self, items: I)
+    where
+        I: IntoIterator<Item = IndexedNoteEntry>,
+    {
+        self.wal.extend(items);
+        if self.wal.len() >= self.max_wal_size {
+            tracing::info!("WAL limit reached, flushing to DB");
+            let wal = std::mem::take(&mut self.wal);
+            let mut stmt = self.conn.prepare("INSERT INTO Txs (?1, ?2, ?3)").unwrap();
+            for (idx, tx) in wal {
+                // TODO: Add fmd flag
+                stmt.execute([idx.serialize_to_vec(), tx.serialize_to_vec(), vec![]])
+                    .unwrap();
+            }
+        }
+    }
+}
+
+impl Drop for DbConn {
+    fn drop(&mut self) {
+        let wal = std::mem::take(&mut self.wal);
+        let Ok(mut stmt) = self.conn.prepare("INSERT INTO Txs (?1, ?2, ?3)") else {
+            return;
+        };
+        for (idx, tx) in wal {
+            // TODO: Add fmd flag
+            _ = stmt
+                .execute([idx.serialize_to_vec(), tx.serialize_to_vec(), vec![]])
+                .unwrap();
+        }
+    }
+}
+
+/// The type in charge of keeping the DB in sync with a MASP indexer
+/// by downloading the latest MASP txs.
+pub struct Fetcher {
+    /// The block we are synced up to
+    fetched: FetchedRanges,
+    /// A client for talking with a MASP indexer
+    indexer: IndexerMaspClient,
+    /// A db connection
+    conn: DbConn,
+    /// A set of active fetching tasks
+    tasks: Tasks,
+    /// A listener for a shutdown signal that is used for graceful shutdowns.
+    interrupt_flag: AtomicFlag,
+    /// Keeps track of interrupts and errors while fetching
+    state: FetcherState,
+    /// Listens for interrupt signals
+    shutdown_signal: ShutdownSignalChan,
+}
+
+impl Fetcher {
+    /// Create a new fetcher
+    pub fn new(url: reqwest::Url, conn: Connection, max_wal_size: usize) -> eyre::Result<Self> {
+        let indexer_client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let (message_sender, message_receiver) = flume::bounded(DEFAULT_BUF_SIZE);
+        let shutdown_signal = install_shutdown_signal(true);
+        let fetched_ranges = if let Ok(bytes) = std::fs::read(kassandra_dir().join(FETCHER_FILE)) {
+            <FetchedRanges as BorshDeserialize>::try_from_slice(&bytes).wrap_err(format!(
+                "Failed to deserialize the contents of {FETCHER_FILE}"
+            ))?
+        } else {
+            FetchedRanges::default()
+        };
+
+        Ok(Self {
+            fetched: fetched_ranges,
+            indexer: IndexerMaspClient::new(indexer_client, url, true, 50),
+            conn: DbConn {
+                conn,
+                wal: Default::default(),
+                max_wal_size,
+            },
+            tasks: Tasks {
+                message_receiver,
+                message_sender,
+                active_tasks: AsyncCounter::new(),
+                panic_flag: PanicFlag::default(),
+            },
+            interrupt_flag: Default::default(),
+            state: FetcherState::Normal,
+            shutdown_signal,
+        })
+    }
+
+    /// Runs a loop until interrupted. Each iteration of the loop
+    /// queries the latest block height and downloads batches of
+    /// MASP txs up to that block height and saves them to the DB.
+    pub async fn run(&mut self) -> Result<(), eyre::Error> {
+        self.check_exit_conditions();
+        // keep trying to sync to the tip of the chain
+        loop {
+            if let ControlFlow::Break(_) = self.sync().await? {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Fetch all masp txs up to the tip of the chain
+    async fn sync(&mut self) -> Result<ControlFlow<()>, eyre::Error> {
+        let Ok(Some(latest_height)) = self.indexer.last_block_height().await else {
+            return Err(eyre::eyre!(
+                "Could not fetch latest block from MASP Indexer."
+            ));
+        };
+        tracing::info!(
+            "Fetching from block {}..={}",
+            self.fetched.first(),
+            latest_height
+        );
+        for from in (self.fetched.first().0..=latest_height.0).step_by(BATCH_SIZE) {
+            let to = (from + BATCH_SIZE as u64 - 1).min(latest_height.0);
+            for [from, to] in self.fetched.blocks_left_to_fetch(from, to) {
+                self.spawn_fetch_txs(from, to)
+            }
+        }
+        while let Some(fetched) = self
+            .tasks
+            .get_next_message(self.interrupt_flag.clone())
+            .await
+        {
+            self.check_exit_conditions();
+            self.handle_fetched(fetched);
+        }
+        match std::mem::replace(&mut self.state, FetcherState::Normal) {
+            FetcherState::Errored(err) => Err(err),
+            FetcherState::Interrupted => Ok(ControlFlow::Break(())),
+            FetcherState::Normal => Ok(ControlFlow::Continue(())),
+        }
+    }
+
+    fn handle_fetched(&mut self, fetched: Fetched) {
+        match fetched {
+            Ok((from, to, fetched)) => {
+                tracing::info!("Fetched blocks {from}..={to} ");
+                self.fetched.insert(from, to);
+                self.save();
+                self.conn.extend(fetched);
+            }
+            Err(TaskError {
+                error,
+                context: [from, to],
+            }) => {
+                tracing::error!("Fetch task encountered error: {error}");
+                if !matches!(
+                    self.state,
+                    FetcherState::Errored(_) | FetcherState::Interrupted
+                ) {
+                    self.spawn_fetch_txs(from, to)
+                }
+            }
+        }
+    }
+
+    /// Spawn a new fetch task
+    fn spawn_fetch_txs(&self, from: BlockHeight, to: BlockHeight) {
+        let sender = self.tasks.message_sender.clone();
+        let guard = (
+            self.tasks.active_tasks.clone(),
+            self.tasks.panic_flag.clone(),
+        );
+        let client = self.indexer.clone();
+        let interrupt = self.interrupt_flag.clone();
+        tokio::task::spawn(async move {
+            let _guard = guard;
+            let wrapped_fut = std::future::poll_fn(move |cx| {
+                if interrupt.get() {
+                    Poll::Ready(None)
+                } else {
+                    Pin::new(&mut Box::pin({
+                        let client = client.clone();
+                        async move {
+                            client
+                                .fetch_shielded_transfers(from, to)
+                                .await
+                                .wrap_err("Failed to fetch shielded transfers")
+                                .map_err(|error| TaskError {
+                                    error,
+                                    context: [from, to],
+                                })
+                                .map(|fetched| (from, to, fetched))
+                        }
+                    }))
+                    .poll(cx)
+                    .map(Some)
+                }
+            });
+            if let Some(msg) = wrapped_fut.await {
+                sender.send_async(msg).await.unwrap()
+            }
+        });
+    }
+
+    fn check_exit_conditions(&mut self) {
+        if hints::unlikely(self.tasks.panic_flag.panicked()) {
+            self.state = FetcherState::Errored(eyre!(
+                "A worker thread panicked during the shielded sync".to_string(),
+            ));
+        }
+        if matches!(
+            &self.state,
+            FetcherState::Interrupted | FetcherState::Errored(_)
+        ) {
+            return;
+        }
+        if self.shutdown_signal.received() {
+            self.state = FetcherState::Interrupted;
+            self.interrupt_flag.set();
+        }
+    }
+
+    fn save(&self) {
+        let to_save = self.fetched.serialize_to_vec();
+        std::fs::write(kassandra_dir().join(FETCHER_FILE), to_save).unwrap();
+    }
+}

--- a/host/src/db/utils.rs
+++ b/host/src/db/utils.rs
@@ -49,10 +49,6 @@ impl AsyncCounter {
             }),
         }
     }
-
-    pub fn count(&self) -> usize {
-        self.inner.value()
-    }
 }
 
 impl Clone for AsyncCounter {
@@ -99,26 +95,6 @@ impl AtomicFlag {
     }
 }
 
-#[derive(Clone, Default)]
-pub struct PanicFlag {
-    inner: AtomicFlag,
-}
-
-impl PanicFlag {
-    #[inline(always)]
-    pub fn panicked(&self) -> bool {
-        self.inner.get()
-    }
-}
-
-impl Drop for PanicFlag {
-    fn drop(&mut self) {
-        if std::thread::panicking() {
-            self.inner.set();
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct InterruptFlag {
     send: Arc<tokio::sync::watch::Sender<bool>>,
@@ -130,12 +106,12 @@ impl InterruptFlag {
         let (send, recv) = tokio::sync::watch::channel(false);
         Self {
             send: Arc::new(send),
-            recv: Arc::new(Mutex::new(recv))
+            recv: Arc::new(Mutex::new(recv)),
         }
     }
 
     pub async fn dropped(&mut self) -> bool {
-        _ =  self.recv.lock().await.changed().await;
+        _ = self.recv.lock().await.changed().await;
         true
     }
 }

--- a/host/src/db/utils.rs
+++ b/host/src/db/utils.rs
@@ -1,0 +1,405 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{self, AtomicBool, AtomicUsize};
+use std::task::{Context, Poll};
+
+use borsh::BorshDeserialize;
+use futures::task::AtomicWaker;
+use namada::borsh::BorshSerialize;
+use namada::chain::BlockHeight;
+
+pub struct TaskError<C> {
+    pub error: eyre::Error,
+    pub context: C,
+}
+
+struct AsyncCounterInner {
+    waker: AtomicWaker,
+    count: AtomicUsize,
+}
+
+impl AsyncCounterInner {
+    fn increment(&self) {
+        self.count.fetch_add(1, atomic::Ordering::Relaxed);
+    }
+
+    fn decrement_then_wake(&self) -> bool {
+        // NB: if the prev value is 1, the new value
+        // is eq to 0, which means we must wake the
+        // waiting future
+        self.count.fetch_sub(1, atomic::Ordering::Relaxed) == 1
+    }
+
+    fn value(&self) -> usize {
+        self.count.load(atomic::Ordering::Relaxed)
+    }
+}
+
+pub struct AsyncCounter {
+    inner: Arc<AsyncCounterInner>,
+}
+
+impl AsyncCounter {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(AsyncCounterInner {
+                waker: AtomicWaker::new(),
+                count: AtomicUsize::new(0),
+            }),
+        }
+    }
+}
+
+impl Clone for AsyncCounter {
+    fn clone(&self) -> Self {
+        let inner = Arc::clone(&self.inner);
+        inner.increment();
+        Self { inner }
+    }
+}
+
+impl Drop for AsyncCounter {
+    fn drop(&mut self) {
+        if self.inner.decrement_then_wake() {
+            self.inner.waker.wake();
+        }
+    }
+}
+
+impl Future for AsyncCounter {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.inner.value() == 0 {
+            Poll::Ready(())
+        } else {
+            self.inner.waker.register(cx.waker());
+            Poll::Pending
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct AtomicFlag {
+    inner: Arc<AtomicBool>,
+}
+
+impl AtomicFlag {
+    pub fn set(&self) {
+        self.inner.store(true, atomic::Ordering::Relaxed)
+    }
+
+    pub fn get(&self) -> bool {
+        self.inner.load(atomic::Ordering::Relaxed)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct PanicFlag {
+    #[cfg(not(target_family = "wasm"))]
+    inner: AtomicFlag,
+}
+
+impl PanicFlag {
+    #[inline(always)]
+    pub fn panicked(&self) -> bool {
+        self.inner.get()
+    }
+}
+
+impl Drop for PanicFlag {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            self.inner.set();
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct DropFlag {
+    #[cfg(not(target_family = "wasm"))]
+    inner: AtomicFlag,
+}
+
+impl DropFlag {
+    #[inline(always)]
+    pub fn dropped(&self) -> bool {
+        self.inner.get()
+    }
+}
+
+impl Drop for DropFlag {
+    fn drop(&mut self) {
+        self.inner.set();
+    }
+}
+
+#[derive(Clone, Default, BorshSerialize, BorshDeserialize)]
+pub struct FetchedRanges(Vec<BlockHeight>);
+
+impl FetchedRanges {
+    /// Get the first block height not contained in `self`
+    pub fn first(&self) -> BlockHeight {
+        if self.0.is_empty() {
+            BlockHeight::first()
+        } else {
+            self.0[1].checked_add(1).unwrap()
+        }
+    }
+
+    /// Check if one of the ranges contains `height`
+    pub fn contains(&self, height: &BlockHeight) -> bool {
+        self.0.chunks(2).any(|r| r[0] <= *height && *height <= r[1])
+    }
+
+    /// Insert a new interval
+    pub fn insert(&mut self, from: BlockHeight, to: BlockHeight) {
+        if self.0.is_empty() {
+            self.0.push(from);
+            self.0.push(to);
+            return;
+        }
+        let contains_to = self.contains(&to);
+        self.0.retain(|x| *x < from || *x > to);
+        let from_ix = self.find_index(&from);
+
+        if !contains_to {
+            self.0.insert(from_ix, to);
+        }
+        if from_ix & 1 == 0 {
+            self.0.insert(from_ix, from);
+        }
+        self.simplify();
+    }
+
+    fn simplify(&mut self) {
+        if self.0.is_empty() {
+            return;
+        }
+        let mut simplified = Vec::with_capacity(self.0.len());
+
+        for (ix, b) in self.0.iter().enumerate().step_by(2) {
+            if ix == 0 {
+                simplified.push(*b);
+                continue;
+            }
+            if self.0[ix - 1].0 == b.0 - 1 || self.0[ix - 1].0 == b.0 {
+                continue;
+            } else {
+                simplified.push(self.0[ix - 1]);
+                simplified.push(self.0[ix]);
+            }
+        }
+        simplified.push(*self.0.last().unwrap());
+        std::mem::swap(&mut self.0, &mut simplified);
+    }
+
+    fn find_index(&self, h: &BlockHeight) -> usize {
+        self.0
+            .iter()
+            .enumerate()
+            .find(|(_, x)| x > &h)
+            .map(|(ix, _)| ix)
+            .unwrap_or_else(|| self.0.len())
+    }
+
+    /// Given an interval [from, to], finds the sub-intervals not contained in `self`
+    pub fn blocks_left_to_fetch(&self, from: u64, to: u64) -> Vec<[BlockHeight; 2]> {
+        let from = BlockHeight::from(from);
+        let to = BlockHeight::from(to);
+        const ZERO: BlockHeight = BlockHeight(0);
+
+        if from > to {
+            panic!("Empty range passed to `blocks_left_to_fetch`, [{from}, {to}]");
+        }
+        if from == ZERO || to == ZERO {
+            panic!("Block height values start at 1");
+        }
+        let mut to_fetch = Vec::with_capacity((to.0 - from.0 + 1) as usize);
+        let mut current_from = from;
+        let mut need_to_fetch = true;
+
+        for height in (from.0..=to.0).map(BlockHeight) {
+            let height_in_cache = self.contains(&height);
+
+            // cross an upper gap boundary
+            if need_to_fetch && height_in_cache {
+                if height > current_from {
+                    to_fetch.push([
+                        current_from,
+                        height.checked_sub(1).expect("Height is greater than zero"),
+                    ]);
+                }
+                need_to_fetch = false;
+            } else if !need_to_fetch && !height_in_cache {
+                // cross a lower gap boundary
+                current_from = height;
+                need_to_fetch = true;
+            }
+        }
+        if need_to_fetch {
+            to_fetch.push([current_from, to]);
+        }
+        to_fetch
+    }
+}
+
+#[cfg(test)]
+mod test_utils {
+    use super::*;
+
+    #[test]
+    fn test_ranges() {
+        //Basic cases
+        let mut ranges = FetchedRanges::default();
+        ranges.insert(5.into(), 5.into());
+        assert_eq!(ranges.0, vec![BlockHeight(5), BlockHeight(5)]);
+        ranges.insert(2.into(), 4.into());
+        assert_eq!(ranges.0, vec![BlockHeight(2), BlockHeight(5)]);
+        ranges.insert(7.into(), 8.into());
+        assert_eq!(
+            ranges.0,
+            vec![
+                BlockHeight(2),
+                BlockHeight(5),
+                BlockHeight(7),
+                BlockHeight(8)
+            ]
+        );
+
+        // Overlaps
+        let mut ranges = FetchedRanges(vec![
+            BlockHeight(5),
+            BlockHeight(7),
+            BlockHeight(10),
+            BlockHeight(12),
+            BlockHeight(16),
+            BlockHeight(18),
+        ]);
+        ranges.insert(BlockHeight(9), BlockHeight(14));
+        assert_eq!(
+            ranges.0,
+            vec![
+                BlockHeight(5),
+                BlockHeight(7),
+                BlockHeight(9),
+                BlockHeight(14),
+                BlockHeight(16),
+                BlockHeight(18)
+            ]
+        );
+        ranges.insert(BlockHeight(7), BlockHeight(16));
+        assert_eq!(ranges.0, vec![BlockHeight(5), BlockHeight(18)]);
+
+        let mut ranges = FetchedRanges(vec![
+            BlockHeight(5),
+            BlockHeight(7),
+            BlockHeight(9),
+            BlockHeight(14),
+            BlockHeight(16),
+            BlockHeight(18),
+        ]);
+        ranges.insert(BlockHeight(8), BlockHeight(15));
+        assert_eq!(ranges.0, vec![BlockHeight(5), BlockHeight(18)]);
+
+        // intersections
+        let mut ranges = FetchedRanges(vec![
+            BlockHeight(5),
+            BlockHeight(7),
+            BlockHeight(10),
+            BlockHeight(12),
+            BlockHeight(16),
+            BlockHeight(18),
+        ]);
+        ranges.insert(BlockHeight(6), BlockHeight(14));
+        assert_eq!(
+            ranges.0,
+            vec![
+                BlockHeight(5),
+                BlockHeight(14),
+                BlockHeight(16),
+                BlockHeight(18)
+            ]
+        );
+
+        let mut ranges = FetchedRanges(vec![
+            BlockHeight(5),
+            BlockHeight(6),
+            BlockHeight(10),
+            BlockHeight(12),
+            BlockHeight(16),
+            BlockHeight(18),
+        ]);
+        ranges.insert(BlockHeight(8), BlockHeight(17));
+        assert_eq!(
+            ranges.0,
+            vec![
+                BlockHeight(5),
+                BlockHeight(6),
+                BlockHeight(8),
+                BlockHeight(18)
+            ]
+        );
+
+        let mut ranges = FetchedRanges(vec![
+            BlockHeight(5),
+            BlockHeight(7),
+            BlockHeight(10),
+            BlockHeight(12),
+            BlockHeight(16),
+            BlockHeight(18),
+        ]);
+        ranges.insert(BlockHeight(6), BlockHeight(17));
+        assert_eq!(ranges.0, vec![BlockHeight(5), BlockHeight(18)]);
+
+        // endpoints
+        let mut ranges = FetchedRanges(vec![
+            BlockHeight(5),
+            BlockHeight(7),
+            BlockHeight(10),
+            BlockHeight(12),
+            BlockHeight(16),
+            BlockHeight(18),
+        ]);
+        ranges.insert(BlockHeight(7), BlockHeight(14));
+        assert_eq!(
+            ranges.0,
+            vec![
+                BlockHeight(5),
+                BlockHeight(14),
+                BlockHeight(16),
+                BlockHeight(18)
+            ]
+        );
+
+        let mut ranges = FetchedRanges(vec![
+            BlockHeight(5),
+            BlockHeight(6),
+            BlockHeight(10),
+            BlockHeight(12),
+            BlockHeight(16),
+            BlockHeight(18),
+        ]);
+        ranges.insert(BlockHeight(8), BlockHeight(16));
+        assert_eq!(
+            ranges.0,
+            vec![
+                BlockHeight(5),
+                BlockHeight(6),
+                BlockHeight(8),
+                BlockHeight(18)
+            ]
+        );
+
+        let mut ranges = FetchedRanges(vec![
+            BlockHeight(5),
+            BlockHeight(6),
+            BlockHeight(10),
+            BlockHeight(12),
+            BlockHeight(16),
+            BlockHeight(18),
+        ]);
+        ranges.insert(BlockHeight(6), BlockHeight(16));
+        assert_eq!(ranges.0, vec![BlockHeight(5), BlockHeight(18)]);
+    }
+}

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -66,7 +66,6 @@ async fn main() -> eyre::Result<()> {
         .await
         .wrap_err("Could not bind to port to listen for incoming connections")?;
 
-
     loop {
         select! {
             incoming = listener.accept() => {

--- a/shared/src/communication/tcp.rs
+++ b/shared/src/communication/tcp.rs
@@ -1,12 +1,13 @@
 //! Communication primitives for talking with hosts
 
-use crate::ReadWriteByte;
-use crate::tee::EnclaveComm;
 use std::io::ErrorKind;
 use std::io::prelude::*;
 use std::net::{TcpListener, TcpStream};
 use std::prelude::rust_2024::Vec;
 use std::{io, vec};
+
+use crate::ReadWriteByte;
+use crate::tee::EnclaveComm;
 
 const ENCLAVE_ADDRESS: &str = "0.0.0.0:12345";
 

--- a/shared/src/communication/tcp.rs
+++ b/shared/src/communication/tcp.rs
@@ -1,12 +1,12 @@
 //! Communication primitives for talking with hosts
 
+use crate::ReadWriteByte;
+use crate::tee::EnclaveComm;
+use std::io::ErrorKind;
 use std::io::prelude::*;
 use std::net::{TcpListener, TcpStream};
 use std::prelude::rust_2024::Vec;
 use std::{io, vec};
-use std::io::ErrorKind;
-use crate::ReadWriteByte;
-use crate::tee::EnclaveComm;
 
 const ENCLAVE_ADDRESS: &str = "0.0.0.0:12345";
 

--- a/shared/src/tee.rs
+++ b/shared/src/tee.rs
@@ -24,7 +24,7 @@ pub trait RemoteAttestation: Clone {
 
 /// High level methods for the enclave to communicate with
 /// its host and clients.
-pub trait EnclaveComm: FramedBytes  {
+pub trait EnclaveComm: FramedBytes {
     /// Instantiate the communication channel
     fn init() -> Self;
 

--- a/shared/src/tee.rs
+++ b/shared/src/tee.rs
@@ -24,7 +24,7 @@ pub trait RemoteAttestation: Clone {
 
 /// High level methods for the enclave to communicate with
 /// its host and clients.
-pub trait EnclaveComm: FramedBytes + Clone {
+pub trait EnclaveComm: FramedBytes  {
     /// Instantiate the communication channel
     fn init() -> Self;
 

--- a/tdx/Cargo.lock
+++ b/tdx/Cargo.lock
@@ -416,7 +416,7 @@ checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
 name = "fmd-enclave-service"
 version = "0.0.1"
 dependencies = [
- "fuzzy-message-detection",
+ "polyfuzzy",
  "shared",
  "x25519-dalek",
 ]
@@ -443,17 +443,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "fuzzy-message-detection"
-version = "0.1.0"
-dependencies = [
- "curve25519-dalek",
- "rand_core",
- "serde",
- "sha2",
- "subtle",
-]
 
 [[package]]
 name = "generic-array"
@@ -947,6 +936,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyfuzzy"
+version = "0.1.0"
+source = "git+https://github.com/anoma/shielded-state-sync#f0c4dc06219db3192f74a8f67b64f29e01410bb1"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,8 +1191,8 @@ version = "0.0.1"
 dependencies = [
  "chacha20poly1305",
  "cobs",
- "fuzzy-message-detection",
  "hex",
+ "polyfuzzy",
  "rand_core",
  "serde",
  "serde_cbor",


### PR DESCRIPTION
Does essentially two things:

1. Moves the `check_exit_conditions` inside the loop in `run` to make the client responsive to signals
2. Makes `spawn_fetch_txs` `async`, and changes it to be an associated function instead of a method. The passed-in argument are cloned (they are all behind `Arc`s) and the callers spawn this function in a new `tokio::task`. Also, the handles are collected and joined on before returning from ´sync´