### PR TITLE
Perform FMD on registered keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
 name = "fmd-enclave-service"
 version = "0.0.1"
 dependencies = [
+ "chacha20poly1305",
  "polyfuzzy",
  "shared",
  "x25519-dalek",
@@ -2529,11 +2530,13 @@ dependencies = [
  "home",
  "namada_sdk",
  "once_cell",
+ "polyfuzzy",
  "rayon",
  "reqwest 0.12.15",
  "rusqlite",
  "serde",
  "serde_cbor",
+ "serde_json",
  "shared",
  "tokio",
  "tokio-scoped",
@@ -6446,6 +6449,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_cbor",
+ "sha2 0.10.8",
  "tdx-quote",
  "thiserror 2.0.12",
  "x25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [ "client", "enclave", "host", "shared", "transparent"]
 
 [workspace.dependencies]
 borsh = "1.2"
-chacha20poly1305 = "0.10.1"
+chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["alloc"] }
 clap = { version = "4.5.32", features = ["derive"] }
 curve25519-dalek = { version = "4.1.3", default-features = false }
 eyre = "0.6.12"
@@ -20,6 +20,8 @@ rand_core = { version = "0.6", default-features = false }
 reqwest = "0.12.14"
 serde = { version = "1.0.218" , default-features = false, features = ["derive"]}
 serde_cbor = { version = "0.11.2", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.10.8", default-features = false }
+serde_json = { version = "1.0.140", default-features = false }
 thiserror = {  version = "2.0.12" , default-features = false}
 toml = "0.8.20"
 tracing = "0.1.41"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,7 +21,7 @@ hkdf = "0.12.4"
 rand_core.workspace = true
 serde_cbor.workspace = true
 serde_json = { version = "1.0.140", default-features = false, features = ["alloc"] }
-sha2 = "0.10.8"
+sha2.workspace = true
 shared = { path = "../shared", features = ["std"] }
 tdx-quote = { version = "0.0.3", default-features = false, optional = true }
 thiserror.workspace = true

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,5 +1,3 @@
-use crate::com::OutgoingTcp;
-use crate::ratls::register_fmd_key;
 use chacha20poly1305::Key;
 use clap::{Parser, Subcommand};
 use fmd::fmd2_compact::CompactSecretKey;
@@ -7,6 +5,9 @@ use hkdf::Hkdf;
 use shared::db::EncKey;
 use shared::{ClientMsg, ServerMsg};
 use tracing_subscriber::fmt::SubscriberBuilder;
+
+use crate::com::OutgoingTcp;
+use crate::ratls::register_fmd_key;
 
 mod ratls;
 

--- a/client/src/ratls.rs
+++ b/client/src/ratls.rs
@@ -6,8 +6,6 @@
 //! clients is registering clients' FMD detection keys with the
 //! enclave.
 
-use crate::GAMMA;
-use crate::com::OutgoingTcp;
 use fmd::fmd2_compact::{CompactSecretKey, MultiFmd2CompactScheme};
 use fmd::{KeyExpansion, MultiFmdScheme};
 use rand_core::{OsRng, RngCore};
@@ -15,6 +13,9 @@ use shared::db::EncKey;
 use shared::ratls::{Connection, FmdKeyRegistration};
 use shared::tee::EnclaveClient;
 use shared::{AckType, ClientMsg, ServerMsg};
+
+use crate::GAMMA;
+use crate::com::OutgoingTcp;
 
 /// Initialize a new TLS connection with the enclave.
 /// The handshake phase establishes a shared key via DHKE.

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.1"
 edition = "2024"
 
 [dependencies]
+chacha20poly1305.workspace = true
 fmd.workspace = true
 shared = { path = "../shared" }
 x25519-dalek = "2.0.1"

--- a/enclave/src/fmd.rs
+++ b/enclave/src/fmd.rs
@@ -1,0 +1,119 @@
+//! The fuzzy message detection logic the enclave must perform
+
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+use chacha20poly1305::aead::Aead;
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
+use fmd::MultiFmdScheme;
+use fmd::fmd2_compact::{FlagCiphertexts, MultiFmd2CompactScheme};
+use shared::MsgToHost;
+use shared::db::{EncKey, EncryptedResponse, Index};
+use shared::ratls::FmdKeyRegistration;
+use shared::tee::{EnclaveComm, EnclaveRNG, RemoteAttestation};
+
+use crate::{Ctx, GAMMA};
+
+/// The current status of which MASP txs a user
+/// should trial decrypt
+pub struct IndexSet {
+    /// The last block height that FMD has been done
+    /// for this user
+    pub synced_to: u64,
+    /// The indexed txs corresponding the MASP txs that
+    /// the user should trial decrypt. Stored here opaquely
+    pub indices: Vec<Index>,
+}
+
+impl Default for IndexSet {
+    fn default() -> Self {
+        Self {
+            synced_to: 1,
+            indices: Vec::new(),
+        }
+    }
+}
+
+impl From<u64> for IndexSet {
+    fn from(value: u64) -> Self {
+        Self {
+            synced_to: value,
+            indices: Vec::new(),
+        }
+    }
+}
+
+impl IndexSet {
+    /// The next block height to perform FMD on.
+    pub(crate) fn next(&self) -> u64 {
+        self.synced_to + 1
+    }
+
+    /// Advance the block height synced to by one
+    fn advance(&mut self) {
+        self.synced_to += 1;
+    }
+
+    /// Add the encryption of `self` to the
+    /// results contained in the response to the host.
+    fn add_result(&self, enc_key: &EncKey, nonce: Nonce, msg: MsgToHost) -> MsgToHost {
+        let cipher = ChaCha20Poly1305::new(enc_key.into());
+        match cipher.encrypt(&nonce, self.index_bytes().as_slice()) {
+            Err(e) => MsgToHost::Error(e.to_string()),
+            Ok(indices) => match msg {
+                msg @ MsgToHost::Error(_) => msg,
+                MsgToHost::FmdResults(mut results) => {
+                    results.push(EncryptedResponse {
+                        owner: enc_key.hash(),
+                        nonce: *nonce.as_ref(),
+                        indices,
+                    });
+                    MsgToHost::FmdResults(results)
+                }
+                _ => unreachable!(),
+            },
+        }
+    }
+
+    fn index_bytes(&self) -> Vec<u8> {
+        self.indices.iter().flat_map(|ix| ix.as_bytes()).collect()
+    }
+}
+
+/// Check the input flags against all registered keys.
+///
+/// On success, add this flag's index to the registered key's data.
+/// Creates a message for the host with encrypted versions of each
+/// key's updated index sets.
+pub fn check_flags<RA, COM, RNG>(
+    ctx: &mut Ctx<RA, COM, RNG>,
+    registered_keys: &mut [(FmdKeyRegistration, IndexSet)],
+    flags: Vec<(Index, Option<FlagCiphertexts>)>,
+) -> MsgToHost
+where
+    RA: RemoteAttestation,
+    COM: EnclaveComm,
+    RNG: EnclaveRNG,
+{
+    let scheme = MultiFmd2CompactScheme::new(GAMMA, 1);
+    let mut response = MsgToHost::FmdResults(Vec::new());
+    for (key, indices) in registered_keys.iter_mut() {
+        for (ix, flag) in flags
+            .iter()
+            .filter(|(ix, _)| ix.height == indices.synced_to + 1)
+        {
+            if match flag {
+                None => true,
+                Some(flag) => scheme.detect(&key.fmd_key, flag),
+            } {
+                indices.indices.push(*ix);
+            }
+        }
+        indices.advance();
+        let mut nonce_bytes = [0u8; 12];
+        ctx.rng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from(nonce_bytes);
+        response = indices.add_result(&key.enc_key, nonce, response);
+    }
+    response
+}

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -6,6 +6,10 @@ use alloc::vec::Vec;
 use shared::tee::{EnclaveComm, EnclaveRNG, RemoteAttestation};
 use shared::{MsgFromHost, MsgToHost};
 
+use crate::fmd::{IndexSet, check_flags};
+
+const GAMMA: usize = 12;
+
 #[derive(Clone)]
 struct Ctx<RA, COM, RNG>
 where
@@ -33,6 +37,7 @@ where
     }
 }
 
+mod fmd;
 pub mod ratls;
 
 pub fn main<RA, COM, RNG>()
@@ -51,12 +56,21 @@ where
                     if let Some(key) =
                         ratls::register_key(&mut ctx, x25519_dalek::PublicKey::from(pk.0), nonce)
                     {
-                        registered_keys.push(key);
+                        let synced_height = key.birthday.unwrap_or(1);
+                        registered_keys.push((key, IndexSet::from(synced_height)));
                     }
                 }
                 MsgFromHost::RequestReport { user_data } => {
                     let quote = ctx.ra.get_quote(user_data.0);
                     ctx.com.write(&MsgToHost::Report(quote));
+                }
+                MsgFromHost::RequiredBlocks => {
+                    let heights = registered_keys.iter().map(|(_, ixs)| ixs.next()).collect();
+                    ctx.com.write(&MsgToHost::BlockRequests(heights));
+                }
+                MsgFromHost::RequestedFlags(flags) => {
+                    let response = check_flags(&mut ctx, &mut registered_keys, flags);
+                    ctx.com.write(&response);
                 }
                 _ => {}
             },

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -3,6 +3,7 @@ extern crate alloc;
 
 use alloc::string::ToString;
 use alloc::vec::Vec;
+
 use shared::tee::{EnclaveComm, EnclaveRNG, RemoteAttestation};
 use shared::{MsgFromHost, MsgToHost};
 

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -10,14 +10,16 @@ clap.workspace = true
 eyre.workspace = true
 home.workspace = true
 flume.workspace = true
+fmd.workspace = true
 futures = "0.3.31"
 namada = { package = "namada_sdk", git = "https://github.com/anoma/namada", rev =  "6a088b2e148fbb976d0727f17846c383dcad052c" }
 once_cell = "1.21.1"
 rayon = "1.10.0"
 reqwest = { workspace = true }
 rusqlite = { version = "0.34.0", features = ["bundled"] }
-serde_cbor = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["std"] }
+serde_cbor = { workspace = true, features = ["std"] }
+serde_json.workspace = true
 shared = { path = "../shared", features = ["std"] }
 tokio = { version = "1.44.1", features = ["full"] }
 tokio-scoped = "0.2.0"

--- a/host/src/db.rs
+++ b/host/src/db.rs
@@ -3,14 +3,17 @@
 mod fetch;
 mod utils;
 
+use crate::config::kassandra_dir;
+use crate::db::fetch::Fetcher;
+use borsh::BorshDeserialize;
 use eyre::WrapErr;
+use fmd::fmd2_compact::FlagCiphertexts;
+use namada::tx::IndexedTx;
 use rusqlite::Connection;
+use shared::db::{EncryptedResponse, Index};
 use std::str::FromStr;
 pub use utils::InterruptFlag;
 use uuid::Uuid;
-
-use crate::config::kassandra_dir;
-use crate::db::fetch::Fetcher;
 
 const MASP_DB_PATH: &str = "masp.db3";
 const FMD_DB_PATH: &str = "fmd.db3";
@@ -37,8 +40,9 @@ impl DB {
                 "CREATE TABLE Txs (
                 id INTEGER PRIMARY KEY,
                 idx BLOB NOT NULL,
+                height INTEGER NOT NULL,
                 data BLOB NOT NULL,
-                flag BLOB
+                flag TEXT
                 )",
                 (),
             )
@@ -53,8 +57,8 @@ impl DB {
             let fmd = Connection::open(fmd_db_path).wrap_err("Failed to open the FMD DB")?;
             fmd.execute(
                 "CREATE TABLE Indices (
-                id INTEGER PRIMARY KEY,
-                owner BLOB NOT NULL,
+                owner BLOB NOT NULL PRIMARY KEY,
+                nonce BLOB NOT NULL,
                 idx_set BLOB NOT NULL
             )",
                 (),
@@ -90,6 +94,62 @@ impl DB {
             },
             uuid,
         ))
+    }
+
+    /// Get all flags of MASP txs at the requested block height
+    pub fn get_height(
+        &mut self,
+        height: u64,
+    ) -> eyre::Result<Vec<(Index, Option<FlagCiphertexts>)>> {
+        let mut stmt = self
+            .masp
+            .prepare("SELECT idx, flag FROM Txs WHERE height=?1")
+            .unwrap();
+        let rows: Vec<Result<(Vec<u8>, String), _>> = stmt
+            .query_map([height], |row| Ok((row.get(0)?, row.get(1)?)))
+            .wrap_err("Database query failed")?
+            .collect();
+        Ok(rows
+            .into_iter()
+            .map(|res| match res {
+                Ok((idx, flag_str)) => {
+                    let Ok(idx) = <IndexedTx as BorshDeserialize>::try_from_slice(&idx)
+                        .map(|ix|  Index{ height: ix.block_height.0, tx: ix.block_index.0 })else {
+                        panic!("Could not deserialize `IndexedTx` of masp tx at height: {height}");
+                    };
+                    let flag = serde_json::from_str::<FlagCiphertexts>(&flag_str)
+                        .map(Some)
+                        .unwrap_or_else(|e| {
+                            tracing::error!(
+                                "Could not deserialize `FlagCiphertext` of a row at height {height}: {e}"
+                            );
+                            None
+                        });
+                    (idx, flag)
+                }
+                Err(err) => {
+                    panic!("Failed to read masp txs at height {height} from DB: {err}");
+                }
+            })
+            .collect())
+    }
+
+    /// Update the DB with the latest encrypted index set per user
+    pub fn update_indices(&mut self, new_indices: Vec<EncryptedResponse>) -> eyre::Result<()> {
+        let mut stmt = self
+            .fmd
+            .prepare("INSERT OR REPLACE INTO Indices(nonce, idx_set, owner) VALUES (?1, ?2, ?3)")
+            .unwrap();
+        for EncryptedResponse {
+            owner,
+            nonce,
+            indices,
+        } in new_indices
+        {
+            stmt.execute((nonce, indices, owner))
+                .wrap_err("Could not update FMD db")?;
+        }
+        Ok(())
     }
 
     /// Spawn the update job in the background and save a handle to it.

--- a/host/src/db.rs
+++ b/host/src/db.rs
@@ -3,8 +3,6 @@
 mod fetch;
 mod utils;
 
-use crate::config::kassandra_dir;
-use crate::db::fetch::Fetcher;
 use borsh::BorshDeserialize;
 use eyre::WrapErr;
 use fmd::fmd2_compact::FlagCiphertexts;
@@ -14,6 +12,9 @@ use shared::db::{EncryptedResponse, Index};
 use std::str::FromStr;
 pub use utils::InterruptFlag;
 use uuid::Uuid;
+
+use crate::config::kassandra_dir;
+use crate::db::fetch::Fetcher;
 
 const MASP_DB_PATH: &str = "masp.db3";
 const FMD_DB_PATH: &str = "fmd.db3";

--- a/host/src/scheduler.rs
+++ b/host/src/scheduler.rs
@@ -1,0 +1,84 @@
+//! Module for scheduling the events that the host should handle.
+
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures::future::{BoxFuture, FutureExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::Sleep;
+
+use crate::db::InterruptFlag;
+
+/// A struct for creating biased combined futures
+/// for interrupts, incoming connections, and background work.
+/// This will act as an event scheduler for the host
+pub struct EventScheduler {
+    listener: TcpListener,
+    interrupt_flag: InterruptFlag,
+}
+
+impl EventScheduler {
+    /// Create a new event scheduler
+    pub fn new(listener: TcpListener, interrupt_flag: InterruptFlag) -> Self {
+        Self {
+            listener,
+            interrupt_flag,
+        }
+    }
+
+    /// Get the next scheduled event
+    pub fn next_query(&mut self) -> NextQuery {
+        NextQuery {
+            accept: self.listener.accept().boxed(),
+            dropped: self.interrupt_flag.dropped().boxed(),
+            timeout: Box::pin(tokio::time::sleep(Duration::from_millis(10))),
+        }
+    }
+}
+
+/// The next scheduled event
+pub enum NextEvent {
+    /// An interrupt request was received
+    Interrupt,
+    /// A client request was received
+    Accept(TcpStream),
+    /// Updated registered keys against latest MASP txs.
+    /// This is the default when incoming commands are not
+    /// present.
+    PerformFmd,
+}
+
+/// A future which first checks for an interrupt, then
+/// checks for an incoming client, then defaults to performing
+/// FMD. The default is spaced out with a small sleep to
+/// prevent starving the other futures.
+pub struct NextQuery<'f1, 'f2> {
+    accept: BoxFuture<'f1, std::io::Result<(TcpStream, SocketAddr)>>,
+    dropped: BoxFuture<'f2, bool>,
+    timeout: Pin<Box<Sleep>>,
+}
+
+impl Future for NextQuery<'_, '_> {
+    type Output = NextEvent;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.dropped.as_mut().poll(cx) {
+            Poll::Ready(_) => Poll::Ready(NextEvent::Interrupt),
+            Poll::Pending => match self.accept.as_mut().poll(cx) {
+                Poll::Ready(Ok((stream, _))) => Poll::Ready(NextEvent::Accept(stream)),
+                Poll::Ready(Err(e)) => {
+                    tracing::error!(
+                        "Encountered unexpected error while listening for new connections: {e}"
+                    );
+                    Poll::Ready(NextEvent::PerformFmd)
+                }
+                _ => match self.timeout.as_mut().poll(cx) {
+                    Poll::Ready(_) => Poll::Ready(NextEvent::PerformFmd),
+                    Poll::Pending => Poll::Pending,
+                },
+            },
+        }
+    }
+}

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -8,13 +8,14 @@ edition = "2024"
 std = []
 
 [dependencies]
-chacha20poly1305.workspace = true
+chacha20poly1305 = { workspace = true, features = ["rand_core"] }
 cobs = { version = "0.3.0" , default-features = false, features = ["alloc"] }
 fmd.workspace = true
 hex.workspace = true
 rand_core.workspace = true
 serde.workspace = true
 serde_cbor.workspace = true
+sha2.workspace = true
 tdx-quote = { version = "0.0.3", default-features = false }
 thiserror.workspace = true
 x25519-dalek.workspace = true

--- a/shared/src/communication/mod.rs
+++ b/shared/src/communication/mod.rs
@@ -6,15 +6,15 @@
 #[cfg(feature = "std")]
 pub mod tcp;
 
+use crate::db::{EncryptedResponse, Index};
+use crate::ratls::TlsCiphertext;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
-
+use fmd::fmd2_compact::FlagCiphertexts;
 use serde::de::{DeserializeOwned, Error};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
-
-use crate::ratls::TlsCiphertext;
 
 #[derive(Debug, Copy, Clone)]
 pub struct HexBytes<const N: usize>(pub [u8; N]);
@@ -65,6 +65,8 @@ pub enum MsgToHost {
     RATLS { report: Vec<u8> },
     Report(Vec<u8>),
     KeyRegSuccess,
+    BlockRequests(Vec<u64>),
+    FmdResults(Vec<EncryptedResponse>),
 }
 
 /// Messages from host environment to the enclave
@@ -74,6 +76,8 @@ pub enum MsgFromHost {
     RegisterKey { nonce: u64, pk: HexBytes<32> },
     RequestReport { user_data: HexBytes<64> },
     RATLSAck(AckType),
+    RequiredBlocks,
+    RequestedFlags(Vec<(Index, Option<FlagCiphertexts>)>),
 }
 
 /// Messages from clients to hosts

--- a/shared/src/communication/mod.rs
+++ b/shared/src/communication/mod.rs
@@ -6,15 +6,17 @@
 #[cfg(feature = "std")]
 pub mod tcp;
 
-use crate::db::{EncryptedResponse, Index};
-use crate::ratls::TlsCiphertext;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
+
 use fmd::fmd2_compact::FlagCiphertexts;
 use serde::de::{DeserializeOwned, Error};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
+
+use crate::db::{EncryptedResponse, Index};
+use crate::ratls::TlsCiphertext;
 
 #[derive(Debug, Copy, Clone)]
 pub struct HexBytes<const N: usize>(pub [u8; N]);

--- a/shared/src/db.rs
+++ b/shared/src/db.rs
@@ -1,0 +1,127 @@
+//! Shared types to be stored in the host databases
+
+use core::fmt::Formatter;
+
+use chacha20poly1305::Key;
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A wrapper around a ChaCha key
+///
+/// Used to encrypted enclave responses for users
+pub struct EncKey(Key);
+
+impl EncKey {
+    /// Get the hash of this key
+    pub fn hash(&self) -> [u8; 32] {
+        use sha2::Digest;
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(self.0.as_slice());
+        hasher.finalize().into()
+    }
+}
+
+impl From<Key> for EncKey {
+    fn from(key: Key) -> Self {
+        Self(key)
+    }
+}
+
+impl<'a> From<&'a EncKey> for &'a Key {
+    fn from(key: &'a EncKey) -> Self {
+        &key.0
+    }
+}
+
+impl Serialize for EncKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self.0.as_slice())
+    }
+}
+
+impl<'de> Deserialize<'de> for EncKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct EncKeyVisitor;
+        impl Visitor<'_> for EncKeyVisitor {
+            type Value = EncKey;
+
+            fn expecting(&self, formatter: &mut Formatter) -> core::fmt::Result {
+                formatter.write_str("32 bytes")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let bytes: [u8; 32] = v
+                    .try_into()
+                    .map_err(|_| Error::custom("Unexpected length of encryption key"))?;
+                Ok(EncKey(*Key::from_slice(&bytes)))
+            }
+        }
+
+        deserializer.deserialize_bytes(EncKeyVisitor)
+    }
+}
+
+/// Simplified domain type for indexing a Tx on chain
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub struct Index {
+    pub height: u64,
+    pub tx: u32,
+}
+
+impl Index {
+    pub fn as_bytes(&self) -> [u8; 12] {
+        let mut bytes = [0u8; 12];
+        let h_bytes = self.height.to_le_bytes();
+        let tx_bytes = self.tx.to_le_bytes();
+        for ix in 0..12 {
+            if ix < 8 {
+                bytes[ix] = h_bytes[ix];
+            } else {
+                bytes[ix] = tx_bytes[ix - 8];
+            }
+        }
+        bytes
+    }
+
+    pub fn try_from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != 12 {
+            None
+        } else {
+            let mut h_bytes = [0u8; 8];
+            let mut tx_bytes = [0u8; 4];
+            for ix in 0..12 {
+                if ix < 8 {
+                    h_bytes[ix] = bytes[ix];
+                } else {
+                    tx_bytes[ix - 8] = bytes[ix];
+                }
+            }
+            Some(Self {
+                height: u64::from_le_bytes(h_bytes),
+                tx: u32::from_le_bytes(tx_bytes),
+            })
+        }
+    }
+}
+
+/// The response from the enclave for performing
+/// FMD for a particular uses
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncryptedResponse {
+    /// Hash of user's encryption key used to identify
+    /// when database entries belong to them
+    pub owner: [u8; 32],
+    /// Nonce needed to decrypt the indices
+    pub nonce: [u8; 12],
+    /// encrypted indices
+    pub indices: alloc::vec::Vec<u8>,
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 extern crate std;
 
 pub mod communication;
+pub mod db;
 pub mod ratls;
 pub mod tee;
 

--- a/tdx/Cargo.lock
+++ b/tdx/Cargo.lock
@@ -416,6 +416,7 @@ checksum = "b3ea1ec5f8307826a5b71094dd91fc04d4ae75d5709b20ad351c7fb4815c86ec"
 name = "fmd-enclave-service"
 version = "0.0.1"
 dependencies = [
+ "chacha20poly1305",
  "polyfuzzy",
  "shared",
  "x25519-dalek",
@@ -1196,6 +1197,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_cbor",
+ "sha2",
  "tdx-quote",
  "thiserror",
  "x25519-dalek",

--- a/tdx/src/lib.rs
+++ b/tdx/src/lib.rs
@@ -6,6 +6,7 @@ mod com;
 
 use alloc::string::ToString;
 use alloc::vec::Vec;
+
 use ostd::arch::x86::qemu::{exit_qemu, QemuExitCode};
 use ostd::prelude::*;
 use shared::{MsgFromHost, MsgToHost};


### PR DESCRIPTION
Closes #21 

This PR adds the following:
 - The host provides the next block height (for each registered key) worth of flags to the enclave
 - The enclave scans these flags and creates an updated set of "hits" per regsitered key.
 - These results are encrypted and given back to the host to persist in a DB.