### PR TITLE
Added logic for client to query their masp indices

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,7 +18,7 @@ curve25519-dalek.workspace = true
 fmd  = { workspace = true, features = ["serde"] }
 hex = "0.4.3"
 hkdf = "0.12.4"
-rand_core.workspace = true
+rand_core = {workspace = true, features = ["getrandom"] }
 serde_cbor.workspace = true
 serde_json = { version = "1.0.140", default-features = false, features = ["alloc"] }
 sha2.workspace = true

--- a/client/src/query.rs
+++ b/client/src/query.rs
@@ -1,0 +1,51 @@
+//! Functions for querying the Kassandra service DB for data
+//! relevant to a particular registered key.
+
+use chacha20poly1305::aead::Aead;
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
+use shared::db::{EncKey, IndexList};
+use shared::{ClientMsg, ServerMsg};
+
+use crate::com::OutgoingTcp;
+
+pub fn query_fmd_key(url: &str, enc_key: &EncKey) {
+    let mut stream = OutgoingTcp::new(url);
+    stream.write(ClientMsg::RequestIndices {
+        key_hash: enc_key.hash(),
+    });
+
+    let encrypted = match stream.read() {
+        Ok(ServerMsg::IndicesResponse(resp)) => resp,
+        Ok(ServerMsg::Error(err)) => {
+            tracing::error!("Error reported by server: {err}");
+            panic!("{err}")
+        }
+        _ => {
+            tracing::error!("Unable to parse response from the service.");
+            panic!("Unable to parse response from the service.");
+        }
+    };
+
+    if encrypted.owner != enc_key.hash() {
+        tracing::error!("Received response for data owned by a different key");
+        panic!("Received response for data owned by a different key");
+    }
+
+    let cipher = ChaCha20Poly1305::new(enc_key.into());
+    let nonce = Nonce::from(encrypted.nonce);
+    let Ok(index_bytes) = cipher.decrypt(&nonce, encrypted.indices.as_ref()) else {
+        tracing::error!("Failed to decrypt the response from the service");
+        panic!("Failed to decrypt the response from the service");
+    };
+
+    match IndexList::try_from_bytes(&index_bytes) {
+        None => {
+            tracing::error!("Could not deserialize decrypted response as MASP indices");
+            panic!("Could not deserialize decrypted response as MASP indices");
+        }
+        Some(list) => {
+            let indices = serde_json::to_string_pretty(&list).unwrap();
+            tracing::info!("{}", indices);
+        }
+    }
+}

--- a/shared/src/communication/mod.rs
+++ b/shared/src/communication/mod.rs
@@ -97,6 +97,9 @@ pub enum ClientMsg {
     RATLSAck(AckType),
     /// Request the host's UUID
     RequestUUID,
+    RequestIndices {
+        key_hash: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -115,6 +118,7 @@ pub enum ServerMsg {
     Error(String),
     KeyRegSuccess,
     UUID(String),
+    IndicesResponse(EncryptedResponse),
 }
 
 impl<'a> TryFrom<&'a ClientMsg> for MsgFromHost {


### PR DESCRIPTION
Closes #25 

- Adds a host method for returning fmd db entries for clients
- Adds CLI command to the client to query their indices
- Changes the key hash used to key the fmd db to a hex string


Currently just prints the returned indices to stdout.